### PR TITLE
bug (#24): adds margin to success page

### DIFF
--- a/src/pages/success.astro
+++ b/src/pages/success.astro
@@ -10,3 +10,8 @@ import Layout from '../components/Layout.astro';
         </main>
     </div>
 </Layout>
+<style>
+  html {
+    margin: 0 30px;
+  }
+</style>


### PR DESCRIPTION
closes #24

before:

after:
<img width="1499" alt="CleanShot 2022-07-06 at 13 01 38@2x" src="https://user-images.githubusercontent.com/3611928/177604637-0201f92e-81a2-4af8-8ce7-b12553817671.png">
 